### PR TITLE
Fixed CModelInfoSA exceeding an array boundaries

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -484,17 +484,21 @@ BOOL CModelInfoSA::IsLoaded ( )
 
 BOOL CModelInfoSA::DoIsLoaded ( )
 {
-    DEBUG_TRACE("BOOL CModelInfoSA::IsLoaded ( )");
+    DEBUG_TRACE("BOOL CModelInfoSA::DoIsLoaded ( )");
 
     //return (BOOL)*(BYTE *)(ARRAY_ModelLoaded + 20*dwModelID);
     BOOL bLoaded = pGame->GetStreaming()->HasModelLoaded(m_dwModelID);
-    m_pInterface = ppModelInfo [ m_dwModelID ];
 
-    if ( bLoaded && m_dwModelID < 20000 )
+    if ( m_dwModelID < 20000 )
     {
-        // Check rw object is there
-        if ( !m_pInterface || !m_pInterface->pRwObject )
-            return false;
+        m_pInterface = ppModelInfo[m_dwModelID];
+
+        if ( bLoaded )
+        {
+            // Check rw object is there
+            if (!m_pInterface || !m_pInterface->pRwObject)
+                return false;
+        }
     }
     return bLoaded;
 }
@@ -531,6 +535,7 @@ CBoundingBox * CModelInfoSA::GetBoundingBox ( )
 
 bool CModelInfoSA::IsValid ( )
 {
+    if ( m_dwModelID >= 20000 && m_dwModelID < MODELINFO_MAX ) return true;
     return ppModelInfo [ m_dwModelID ] != 0;
 }
 


### PR DESCRIPTION
When loading an animation ppModelInfo boundaries will be exceeded by its index.
